### PR TITLE
Mention click more obviously in intro paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # QUICK
 
-This project is inspired by [Gooey](https://github.com/chriskiehl/Gooey),
-which generate GUI for a classical python `argparse`-based command line
-program.
+A real quick GUI generator for [click](https://github.com/pallets/click). Inspired by [Gooey](
+https://github.com/chriskiehl/Gooey), the GUI generator for classical Python `argparse`-based command line programs.
 
 ## Install
 


### PR DESCRIPTION
I felt the introductory paragraph of this project's README doesn't clearly explain what this project is about. This change should fix that.

**P.S.:** In addition, could you add a short description to the GitHub project (at the top of the GitHub project start page)? Thanks!