### PR TITLE
Add PyQt5 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click>=6.5
+PyQt5


### PR DESCRIPTION
`requirements.txt` should list PyQt5 as a requirement.

Intentionally leaving out a version number in favor of whatever baseline version the author has in mind.